### PR TITLE
Dynamic network dims

### DIFF
--- a/src/model/gnn_architectures.py
+++ b/src/model/gnn_architectures.py
@@ -60,11 +60,9 @@ class GNN(torch.nn.Module):
         else:
             self.aggregations = aggregations
 
-        self.conv1 = EC_GCNConv(self.dimensions[0], self.dimensions[1], num_edge_colours, self.agg_1)
-        self.conv2 = EC_GCNConv(self.dimensions[1], self.dimensions[2], num_edge_colours, self.agg_2)
+        self.convs = torch.nn.ModuleList()
+        self.lins = torch.nn.ModuleList()
 
-        self.lin_self_1 = torch.nn.Linear(self.dimensions[0], self.dimensions[1])
-        self.lin_self_2 = torch.nn.Linear(self.dimensions[1], self.dimensions[2])
         
         self.output = torch.nn.Sigmoid()
 

--- a/src/model/gnn_architectures.py
+++ b/src/model/gnn_architectures.py
@@ -23,7 +23,7 @@ class EC_GCNConv(MessagePassing):
 
     # in_channels (int) - Size of each input sample
     # out_channels (int) - Size of each output sample
-    def __init__(self, in_channels, out_channels, edge_colours, aggregation):
+    def __init__(self, dimensions, edge_colours, aggregations):
 
         self.aggr = aggregation
         aggr_name = getattr(aggregation, "value", aggregation)

--- a/src/model/gnn_architectures.py
+++ b/src/model/gnn_architectures.py
@@ -53,7 +53,7 @@ class GNN(torch.nn.Module):
 
         self.num_colours = num_edge_colours
         # From layer 0 (left) to layer L (right)
-        self.dimensions = [feature_dimension, 2*feature_dimension, feature_dimension]
+        self.dimensions = dimensions
 
         self.agg_1 = aggregation_1
         self.agg_2 = aggregation_2

--- a/src/model/gnn_architectures.py
+++ b/src/model/gnn_architectures.py
@@ -55,8 +55,10 @@ class GNN(torch.nn.Module):
         # From layer 0 (left) to layer L (right)
         self.dimensions = dimensions
 
-        self.agg_1 = aggregation_1
-        self.agg_2 = aggregation_2
+        if len(aggregations) != self.num_layers:
+            raise ValueError(f"Expected {self.num_layers} aggregations, but got {len(aggregations)}.")
+        else:
+            self.aggregations = aggregations
 
         self.conv1 = EC_GCNConv(self.dimensions[0], self.dimensions[1], num_edge_colours, self.agg_1)
         self.conv2 = EC_GCNConv(self.dimensions[1], self.dimensions[2], num_edge_colours, self.agg_2)

--- a/src/model/gnn_architectures.py
+++ b/src/model/gnn_architectures.py
@@ -81,20 +81,19 @@ class GNN(torch.nn.Module):
     def forward(self, data):
         x, edge_index, edge_colour = data.x, data.edge_index, data.edge_type
 
-        # Layer 1
-        x = self.lin_self_1(x) + self.conv1(x, edge_index, edge_colour)
-        x = torch.relu(x)
-        features_1 = x.detach().clone() # Detached so that it does not participate in the computation graph
+        intermediate_features = []
 
-        # Layer 2
-        x = self.lin_self_2(x) + self.conv2(x, edge_index, edge_colour)
-        # Note: this translation is irrelevant since the bias vectors are not
-        # constrained to the positive reals, therefore it isn't mentioned in
-        # the report. However, I've left it here for completeness since the
-        # models were trained with it.
-        x = self.output(x - 10)
+        for i in range(self.num_layers):
+            x = self.lins[i](x) + self.convs[i](x, edge_index, edge_colour)
 
-        return x, features_1
+            # Apply ReLU and save detached features for all but the final layer
+            if i < self.num_layers - 1:
+                x = torch.relu(x)
+                intermediate_features.append(x.detach().clone())
+            else:
+                x = self.output(x - 10)
+
+        return x, intermediate_features
 
     def layer_dimension(self, layer):
         return self.dimensions[layer]

--- a/src/model/gnn_architectures.py
+++ b/src/model/gnn_architectures.py
@@ -46,10 +46,10 @@ class EC_GCNConv(MessagePassing):
 
 class GNN(torch.nn.Module):
 
-    def __init__(self, feature_dimension, num_edge_colours, aggregation_1, aggregation_2):
+    def __init__(self, dimensions, num_edge_colours, aggregations):
         super(GNN, self).__init__()
 
-        self.num_layers = 2 # Currently hardcoded!
+        self.num_layers = len(dimensions) - 1
 
         self.num_colours = num_edge_colours
         # From layer 0 (left) to layer L (right)

--- a/src/model/gnn_architectures.py
+++ b/src/model/gnn_architectures.py
@@ -46,7 +46,7 @@ class EC_GCNConv(MessagePassing):
 
 class GNN(torch.nn.Module):
 
-    def __init__(self, dimensions, num_edge_colours, aggregations):
+    def __init__(self, dimensions, num_edge_colours, aggregations, conv_builder=EC_GCNConv):
         super(GNN, self).__init__()
 
         self.num_layers = len(dimensions) - 1
@@ -63,6 +63,13 @@ class GNN(torch.nn.Module):
         self.convs = torch.nn.ModuleList()
         self.lins = torch.nn.ModuleList()
 
+        for i in range(self.num_layers):
+            in_dim = self.dimensions[i]
+            out_dim = self.dimensions[i + 1]
+            agg = self.aggregations[i]
+
+            self.convs.append(conv_builder(in_dim, out_dim, num_edge_colours, agg))
+            self.lins.append(torch.nn.Linear(in_dim, out_dim))
         
         self.output = torch.nn.Sigmoid()
 

--- a/src/model/gnn_architectures.py
+++ b/src/model/gnn_architectures.py
@@ -23,7 +23,7 @@ class EC_GCNConv(MessagePassing):
 
     # in_channels (int) - Size of each input sample
     # out_channels (int) - Size of each output sample
-    def __init__(self, dimensions, edge_colours, aggregations):
+    def __init__(self, in_channels, out_channels, edge_colours, aggregation):
 
         self.aggr = aggregation
         aggr_name = getattr(aggregation, "value", aggregation)

--- a/src/model/gnn_architectures.py
+++ b/src/model/gnn_architectures.py
@@ -99,43 +99,40 @@ class GNN(torch.nn.Module):
         return self.dimensions[layer]
 
     def matrix_A(self, layer):
-        if layer == 1:
-            return self.lin_self_1.weight.detach()
-        elif layer == 2:
-            return self.lin_self_2.weight.detach()
-        else:
-            return None
+        # Adjusted for 0-indexing internally while keeping 1-indexing externally
+        idx = layer - 1
+        if 0 <= idx < self.num_layers:
+            return self.lins[idx].weight.detach()
+        return None
 
     def matrix_B(self, layer, colour):
-        if layer == 1:
-            return self.conv1.weights[colour].detach()
-        elif layer == 2:
-            return self.conv2.weights[colour].detach()
-        else:
-            return None
+        idx = layer - 1
+        if 0 <= idx < self.num_layers:
+            # Note: This assumes the custom convolution has a 'weights' attribute
+            if hasattr(self.convs[idx], 'weights'):
+                return self.convs[idx].weights[colour].detach()
+        return None
 
     def bias(self, layer):
-        if layer == 1:
-            return self.lin_self_1.bias.detach()
-        elif layer == 2:
-            return self.lin_self_2.bias.detach() - 10
-        else:
-            return None
+        idx = layer - 1
+        if 0 <= idx < self.num_layers:
+            bias_val = self.lins[idx].bias.detach()
+            if idx == self.num_layers - 1:
+                return bias_val - 10
+            return bias_val
+        return None
 
     def activation(self, layer):
-        if layer == 1:
+        idx = layer - 1
+        if 0 <= idx < self.num_layers - 1:
             return torch.relu
-        elif layer == 2:
-            m = torch.nn.Sigmoid()
-            return m
-        else:
-            return None
+        elif idx == self.num_layers - 1:
+            return torch.nn.Sigmoid()
+        return None
 
     def aggregation_function(self, layer):
-        if layer == 1:
-            return self.agg_1
-        elif layer == 2:
-            return self.agg_2
-        else:
-            return None
+        idx = layer - 1
+        if 0 <= idx < self.num_layers:
+            return self.aggregations[idx]
+        return None
 #

--- a/src/model/gnn_transformation.py
+++ b/src/model/gnn_transformation.py
@@ -21,21 +21,27 @@ def apply_c_encoder(cd_dataset: set[tuple[str,str,str]], internal_encoder):
     return internal_encoder.encode_dataset(cd_dataset)
 
 # Apply Model
-def apply_model(cd_graph:CDGraph, device, model, trace_collector=None):
+def apply_model(cd_graph: CDGraph, device, model, trace_collector=None):
     # PyTorch Encoding: cd_graph -> pytorch geometric graph
     data = Data(x=cd_graph.features, edge_index=cd_graph.edges, edge_type=cd_graph.edge_colours).to(device)
 
     # Apply model
     model.eval()
-    features_layer_2, features_layer_1 = model(data)  # note: features_layer_1 comes already detached
+
+    # Capture the final output tensor and the list of intermediate layer tensors
+    final_features, hidden_features = model(data)
+
     if trace_collector is not None:
         trace_collector.cd_graph = cd_graph
-        trace_collector.fl2 = features_layer_2.detach().clone()
-        trace_collector.fl1 = features_layer_1.clone()
-        trace_collector.fl0 = data.x.detach().clone()
+        trace_collector.input_features = data.x.detach().clone()
+
+        # Safely clone each tensor in the hidden features list
+        trace_collector.hidden_features = [layer.detach().clone() for layer in hidden_features]
+
+        trace_collector.final_features = final_features.detach().clone()
 
     # PyTorch Decoding: pytorch geometric graph -> cd_graph
-    return CDGraph(cd_graph.col_size, cd_graph.delta, features_layer_2.detach().clone(), cd_graph.edges,
+    return CDGraph(cd_graph.col_size, cd_graph.delta, final_features.detach().clone(), cd_graph.edges,
                    cd_graph.edge_colours, cd_graph.node_names)
 
 # Canonical Decoding

--- a/src/rule_extraction/fact_explanation.py
+++ b/src/rule_extraction/fact_explanation.py
@@ -31,7 +31,11 @@ class FactExplainer:
         self.threshold = threshold
         self.external_encoder = external_encoder
         self.internal_encoder = internal_encoder
-        self.activations = [trace.fl0,trace.fl1,trace.fl2] # Index matches layer
+        self.activations = [
+            trace.input_features,  # Layer 0
+            *trace.hidden_features,  # Layers 1 to L-1
+            trace.final_features  # Layer L
+        ]
         self.cd_graph = trace.cd_graph
         self.node_to_index = {node: i for i, node in enumerate(self.cd_graph.node_names)}  # Helpful dictionary
         self.input_dataset = input_dataset

--- a/src/run/run_experiment.py
+++ b/src/run/run_experiment.py
@@ -74,8 +74,10 @@ if __name__ == "__main__":
         train_examples_dataset = parse(check(dd / "train_pos.tsv", "Training positive examples"))
         cd_train_examples = external_encoder.encode_dataset(train_examples_dataset)
 
-        model = GNN(feature_dimension=cd_graph.delta,num_edge_colours=cd_graph.col_size,
-                    aggregation_1=cfg.agg_function_1, aggregation_2=cfg.agg_function_2).to(device)
+        model = GNN(
+            dimensions=[cd_graph.delta, 2*cd_graph.delta, cd_graph.delta],
+            num_edge_colours=cd_graph.col_size,
+            aggregations=[cfg.agg_function_1, cfg.agg_function_2]).to(device)
 
         # TODO: try this: use a non-uniform encoding where much like in the code of the original ICLR paper, we encode
         #  the query facts into the cd_graph that we use. This is expressive enough to support transitivity

--- a/tests/rule_extraction/test_fact_explanation.py
+++ b/tests/rule_extraction/test_fact_explanation.py
@@ -28,7 +28,10 @@ from src.utils.bitset import BitSet
 # Feature 1: current node has features 1 & 2 and S-neighbour with feature 1
 # Feature 2: has an S-neighbour with feature 3 & S-neighbour with feature 4
 def example_model_1(device):
-    model = GNN(feature_dimension=2, num_edge_colours=2,aggregation_1="max",aggregation_2="max").to(device)
+    model = GNN(
+        dimensions=[2,4,2],
+        num_edge_colours=2,
+        aggregations=["max","max"]).to(device)
     # Checks
     assert model.num_layers == 2
     assert model.num_colours == 2
@@ -157,7 +160,10 @@ def get_fact_ex1():
 # Feature 2: current node is c3-connected to one with feature 2 and is c1-connected to a node with feature 1
 # Feature 3: nothing
 def example_model_2(device):
-    model = GNN(feature_dimension=3, num_edge_colours=4,aggregation_1="max",aggregation_2="max").to(device)
+    model = GNN(
+        dimensions=[3,6,3],
+        num_edge_colours=4,
+        aggregations=["max","max"]).to(device)
     # Checks
     assert model.num_layers == 2
     assert model.num_colours == 4

--- a/tests/rule_extraction/test_fact_explanation.py
+++ b/tests/rule_extraction/test_fact_explanation.py
@@ -61,21 +61,21 @@ def example_model_1(device):
         [0., 0., 1., 1.]
     ])
     # Matrix A1
-    model.lin_self_1.weight.data = torch.tensor([
+    model.lins[0].weight.data = torch.tensor([
         [1., 0.],
         [0., 0.],
         [0., 0.],
         [0., 0.]
     ])
     # Matrix A2
-    model.lin_self_2.weight.data = torch.tensor([
+    model.lins[1].weight.data = torch.tensor([
         [1., 1., 0., 0.],
         [0., 0., 0., 0.]
     ])
     # Bias b1
-    model.lin_self_1.bias.data = torch.tensor([0.,0.,-1.,1.])
+    model.lins[0].bias.data = torch.tensor([0.,0.,-1.,1.])
     # Bias b2
-    model.lin_self_2.bias.data = torch.tensor([-2.,-1.])
+    model.lins[1].bias.data = torch.tensor([-2.,-1.])
     return model
 
 def example_cdgraph_1():
@@ -229,7 +229,7 @@ def example_model_2(device):
         [0., 0., 0., 0., 0., 0.]
     ])
     # Matrix A1
-    model.lin_self_1.weight.data = torch.tensor([
+    model.lins[0].weight.data = torch.tensor([
         [1., 0., 0.],
         [0., 0., 1.],
         [0., 0., 0.],
@@ -238,15 +238,15 @@ def example_model_2(device):
         [0., 0., 0.]
     ])
     # Matrix A2
-    model.lin_self_2.weight.data = torch.tensor([
+    model.lins[1].weight.data = torch.tensor([
         [0., 0., 0., 0., 0., 0.],
         [0., 0., 0., 0., 0., 0.],
         [0., 0., 0., 0., 0., 0.]
     ])
     # Bias b1
-    model.lin_self_1.bias.data = torch.tensor([-1,0.,0.,0.,0.,0.])
+    model.lins[0].bias.data = torch.tensor([-1,0.,0.,0.,0.,0.])
     # Bias b2
-    model.lin_self_2.bias.data = torch.tensor([0.,-1.,0.])
+    model.lins[1].bias.data = torch.tensor([0.,-1.,0.])
     return model
 
 def example_cdgraph_2():

--- a/tests/rule_extraction/test_fact_explanation.py
+++ b/tests/rule_extraction/test_fact_explanation.py
@@ -37,26 +37,26 @@ def example_model_1(device):
     assert model.num_colours == 2
     assert model.dimensions == [2,4,2]
     # Matrix B1-c1
-    model.conv1.weights.data[0] = torch.tensor([
+    model.convs[0].weights.data[0] = torch.tensor([
     [0., 0.],
     [1., 0.],
     [0., 1.],
     [0., 0.]
     ])
     # Matrix B1-c2
-    model.conv1.weights.data[1] = torch.tensor([
+    model.convs[0].weights.data[1] = torch.tensor([
         [0., 0.],
         [0., 0.],
         [0., 1.],
         [0., 0.]
     ])
     # Matrix B2-c1
-    model.conv2.weights.data[0] = torch.tensor([
+    model.convs[1].weights.data[0] = torch.tensor([
         [0., 0., 0., 0.],
         [0., 0., 0., 0.]
     ])
     # Matrix B2-c2
-    model.conv2.weights.data[1] = torch.tensor([
+    model.convs[1].weights.data[1] = torch.tensor([
         [1., 0., 0., 0.],
         [0., 0., 1., 1.]
     ])
@@ -169,7 +169,7 @@ def example_model_2(device):
     assert model.num_colours == 4
     assert model.dimensions == [3,6,3]
     # Matrix B1-c1
-    model.conv1.weights.data[0] = torch.tensor([
+    model.convs[0].weights.data[0] = torch.tensor([
     [0., 0., 1.],
     [0., 0., 0.],
     [0., 0., 0.],
@@ -178,7 +178,7 @@ def example_model_2(device):
     [0., 0., 0.]
     ])
     # Matrix B1-c2
-    model.conv1.weights.data[1] = torch.tensor([
+    model.convs[0].weights.data[1] = torch.tensor([
     [0., 0., 0.],
     [0., 0., 0.],
     [0., 0., 0.],
@@ -187,7 +187,7 @@ def example_model_2(device):
     [0., 0., 0.]
     ])
     # Matrix B1-c3
-    model.conv1.weights.data[2] = torch.tensor([
+    model.convs[0].weights.data[2] = torch.tensor([
         [0., 0., 0.],
         [0., 0., 0.],
         [0., 0., 0.],
@@ -196,7 +196,7 @@ def example_model_2(device):
         [0., 0., 0.]
     ])
     # Matrix B1-c4
-    model.conv1.weights.data[3] = torch.tensor([
+    model.convs[0].weights.data[3] = torch.tensor([
         [0., 0., 0.],
         [0., 0., 0.],
         [0., 0., 0.],
@@ -205,25 +205,25 @@ def example_model_2(device):
         [0., 0., 0.]
     ])
     # Matrix B2-c1
-    model.conv2.weights.data[0] = torch.tensor([
+    model.convs[1].weights.data[0] = torch.tensor([
         [0., 0., 0., 0., 0., 0.],
         [1., 0., 0., 0., 0., 0.],
         [0., 0., 0., 0., 0., 0.]
     ])
     # Matrix B2-c2
-    model.conv2.weights.data[1] = torch.tensor([
+    model.convs[1].weights.data[1] = torch.tensor([
         [0., 0., 0., 0., 0., 0.],
         [0., 0., 0., 0., 0., 0.],
         [0., 0., 0., 0., 0., 0.]
     ])
     # Matrix B2-c3
-    model.conv2.weights.data[2] = torch.tensor([
+    model.convs[1].weights.data[2] = torch.tensor([
         [0., 0., 0., 0., 0., 0.],
         [0., 1., 0., 0., 0., 0.],
         [0., 0., 0., 0., 0., 0.]
     ])
     # Matrix B2-c4
-    model.conv2.weights.data[3] = torch.tensor([
+    model.convs[1].weights.data[3] = torch.tensor([
         [0., 0., 0., 0., 0., 0.],
         [0., 0., 0., 0., 0., 0.],
         [0., 0., 0., 0., 0., 0.]

--- a/tests/rule_extraction/test_fact_explanation.py
+++ b/tests/rule_extraction/test_fact_explanation.py
@@ -132,9 +132,9 @@ def make_mock_fe_1():
     threshold = 0.000123 # sigmoid of 1-10 (GNN architecture does this -10)
     apply_model(cd_graph, device, model, trace)
     # Check the activations match what we expect
-    assert torch.equal(trace.fl0,ex_1_1_activation_0())
-    assert torch.equal(trace.fl1,ex_1_1_activation_1())
-    assert torch.equal(trace.fl2,ex_1_1_activation_2())
+    assert torch.equal(trace.input_features,ex_1_1_activation_0())
+    assert torch.equal(trace.hidden_features[0],ex_1_1_activation_1())
+    assert torch.equal(trace.final_features,ex_1_1_activation_2())
     fe = FactExplainer(device,model,threshold,trace,external_encoder,internal_encoder)
     return fe
 
@@ -315,9 +315,9 @@ def make_mock_fe_2():
     threshold = 0.000123 # sigmoid of 1-10 (GNN architecture does this -10)
     apply_model(cd_graph, device, model, trace)
     # Check the activations match what we expect
-    assert torch.equal(trace.fl0,ex_2_2_activation_0())
-    assert torch.equal(trace.fl1,ex_2_2_activation_1())
-    assert torch.equal(trace.fl2,ex_2_2_activation_2())
+    assert torch.equal(trace.input_features,ex_2_2_activation_0())
+    assert torch.equal(trace.hidden_features[0],ex_2_2_activation_1())
+    assert torch.equal(trace.final_features,ex_2_2_activation_2())
     fe = FactExplainer(device,model,threshold,trace,external_encoder,internal_encoder)
     return fe
 


### PR DESCRIPTION
Hello David,

I changed the signature of the GNN constructor to `def __init__(self, dimensions, num_edge_colours, aggregations, conv_builder=EC_GCNConv):`

_Changes_:
- It now dynamically builds lists for all the elements such as convolutions, linear activation layers, activations, etc. 
- Edited the files which instantiated the GNN to match this new signature, the functionality should be unchanged. 
- Changed the tests only so far as to reflect the new naming and indexing of elements as discussed above.
- Updated the FactExplainer class to reflect the dynamic list of activations instead of the hardcoded attributes that where there before.

All 107 tests pass:
```
C:\Users\Surface\.conda\envs\mgnns\python.exe C:/Users/Surface/AppData/Local/Programs/PyCharm/plugins/python-ce/helpers/pycharm/_jb_pytest_runner.py --path C:\Users\Surface\Documents\code\python\mgnns-fork\tests 
Testing started at 2:40 PM ...
Launching pytest with arguments C:\Users\Surface\Documents\code\python\mgnns-fork\tests --no-header --no-summary -q in C:\Users\Surface\Documents\code\python\mgnns-fork\tests

============================= test session starts =============================
collecting ... collected 107 items

config/test_config.py::test_valid_config_loads 
config/test_config.py::test_invalid_data_dir_raises 
config/test_config.py::test_invalid_encoder_type_raises 
config/test_config.py::test_invalid_aggregation_type_raises 
config/test_config.py::test_threshold_out_of_range_raises 
config/test_config.py::test_threshold_not_float_raises 
config/test_config.py::test_negative_clamping_raises 
datalog/test_apply_rules.py::test_is_var PASSED                    [  0%]PASSED               [  1%]PASSED           [  2%]PASSED       [  3%]PASSED         [  4%]PASSED            [  5%]PASSED              [  6%]PASSED                          [  7%]
datalog/test_apply_rules.py::test_match_term_binds_new_var PASSED        [  8%]
datalog/test_apply_rules.py::test_match_term_consistent_existing_var PASSED [  9%]
datalog/test_apply_rules.py::test_match_term_conflicting_existing_var PASSED [ 10%]
datalog/test_apply_rules.py::test_match_term_matching_constant PASSED    [ 11%]
datalog/test_apply_rules.py::test_match_term_mismatching_constant PASSED [ 12%]
datalog/test_apply_rules.py::test_match_term_does_not_mutate_input PASSED [ 13%]
datalog/test_apply_rules.py::test_match_atom_unary_match PASSED          [ 14%]
datalog/test_apply_rules.py::test_match_atom_unary_predicate_mismatch PASSED [ 14%]
datalog/test_apply_rules.py::test_match_atom_binary_match PASSED         [ 15%]
datalog/test_apply_rules.py::test_match_atom_binary_predicate_mismatch PASSED [ 16%]
datalog/test_apply_rules.py::test_match_atom_repeated_variable_self_join_matches PASSED [ 17%]
datalog/test_apply_rules.py::test_match_atom_repeated_variable_self_join_rejects_mismatch PASSED [ 18%]
datalog/test_apply_rules.py::test_split_atoms_simple PASSED              [ 19%]
datalog/test_apply_rules.py::test_split_atoms_ignores_commas_inside_brackets PASSED [ 20%]
datalog/test_apply_rules.py::test_parse_atom_binary PASSED               [ 21%]
datalog/test_apply_rules.py::test_parse_atom_unary PASSED                [ 22%]
datalog/test_apply_rules.py::test_parse_rule PASSED                      [ 23%]
datalog/test_apply_rules.py::test_ground_term_variable PASSED            [ 24%]
datalog/test_apply_rules.py::test_ground_term_constant PASSED            [ 25%]
datalog/test_apply_rules.py::test_ground_term_unbound_variable_raises PASSED [ 26%]
datalog/test_apply_rules.py::test_apply_rule_simple_join_binary_head PASSED [ 27%]
datalog/test_apply_rules.py::test_apply_rule_unary_head PASSED           [ 28%]
datalog/test_apply_rules.py::test_apply_rule_free_head_variable_grounds_with_every_constant PASSED [ 28%]
datalog/test_apply_rules.py::test_apply_rule_no_matching_facts_yields_empty PASSED [ 29%]
encodings/test_canonical.py::test_init_with_predicates 
encodings/test_canonical.py::test_init_with_empty_predicates_adds_dummy 
encodings/test_canonical.py::test_save_and_load 
encodings/test_canonical.py::test_encode_dataset_basic 
encodings/test_canonical.py::test_encode_dataset_unknown_unary_raises 
encodings/test_canonical.py::test_encode_dataset_unknown_binary_raises 
encodings/test_canonical.py::test_decode_graph 
encodings/noncanonical/test_iclr22.py::test_initialisation PASSED            [ 30%]PASSED [ 31%]PASSED                   [ 32%]PASSED            [ 33%]PASSED [ 34%]PASSED [ 35%]PASSED                    [ 36%]
encodings/noncanonical/test_iclr22.py::test_encode_dataset 
encodings/noncanonical/test_iclr22.py::test_decode_binary_fact 
encodings/noncanonical/test_iclr22.py::test_decode_unary_facts 
encodings/noncanonical/test_iclr22.py::test_decoder_dataset 
encodings/noncanonical/test_iclr22.py::test_init_from_file 
encodings/noncanonical/test_iclr22.py::test_save_to_file 
encodings/noncanonical/test_iclr22.py::test_unfold_unary_head 
encodings/noncanonical/test_iclr22.py::test_unfold_binary_head 
encodings/noncanonical/test_iclr22.py::test_unfold_empty 
encodings/noncanonical/test_identity.py::test_encode_decode_dataset_identity PASSED        [ 37%]PASSED        [ 38%]PASSED    [ 39%]PASSED    [ 40%]PASSED       [ 41%]PASSED        [ 42%]PASSED          [ 42%]PASSED     [ 43%]PASSED    [ 44%]PASSED          [ 45%]
encodings/noncanonical/test_identity.py::test_decode_fact_identity 
encodings/noncanonical/test_identity.py::test_get_canonical_equivalent_identity 
encodings/noncanonical/test_identity.py::test_init_from_file 
encodings/noncanonical/test_identity.py::test_save_to_file 
encodings/noncanonical/test_identity.py::test_unfold_simple_tree 
encodings/noncanonical/test_identity.py::test_unfold_empty 
rule_extraction/test_fact_explanation.py::TestFactContext::test_fact_context_ex1 PASSED [ 46%]PASSED [ 47%]PASSED [ 48%]PASSED      [ 49%]PASSED        [ 50%]PASSED  [ 51%]PASSED        [ 52%]
rule_extraction/test_fact_explanation.py::TestFactContext::test_fact_context_ex2 
rule_extraction/test_fact_explanation.py::TestFactExplainer::test_initialisation_ex1 
rule_extraction/test_fact_explanation.py::TestFactExplainer::test_basic_explanation_ex1 
rule_extraction/test_fact_explanation.py::TestFactExplainer::test_fact_explainer_ex1 
rule_extraction/test_fact_explanation.py::TestFactExplainer::test_initialisation_ex2 
rule_extraction/test_fact_explanation.py::TestFactExplainer::test_fact_basic_explanation_ex2 
rule_extraction/test_fact_explanation.py::TestFactExplainer::test_fact_explainer_ex2 
rule_extraction/test_rule_optimisation_3.py::TestDFSFrontier::test_is_empty_initially PASSED [ 53%]PASSED [ 54%]PASSED [ 55%]PASSED [ 56%]PASSED [ 57%]Computing Gamma_i
Length Gamma_i: 3
PASSED [ 57%]PASSED [ 58%]PASSED [ 59%]Computing Gamma_i
Length Gamma_i: 4

rule_extraction/test_rule_optimisation_3.py::TestDFSFrontier::test_pop_returns_last_pushed 
rule_extraction/test_rule_optimisation_3.py::TestBFSFrontier::test_is_empty_initially 
rule_extraction/test_rule_optimisation_3.py::TestBFSFrontier::test_pop_returns_first_pushed 
rule_extraction/test_rule_optimisation_3.py::TestGraphSearch::test_returns_initial_subtree_if_already_sound 
rule_extraction/test_rule_optimisation_3.py::TestGraphSearch::test_finds_sound_successor 
rule_extraction/test_rule_optimisation_3.py::TestGraphSearch::test_returns_none_when_no_sound_subtree_exists 
rule_extraction/test_rule_optimisation_3.py::TestGraphSearch::test_does_not_revisit_explored_nodes 
rule_extraction/test_rule_optimisation_3.py::TestGraphSearch::test_timeout_returns_none 
rule_extraction/test_rule_optimisation_3.py::TestMinimiseRule::test_returns_bfs_result_when_found 
rule_extraction/test_rule_optimisation_3.py::TestMinimiseRule::test_falls_back_to_dfs_when_bfs_times_out 
rule_extraction/test_rule_optimisation_3.py::TestMinimiseRule::test_returns_none_when_both_frontiers_fail 
rule_extraction/test_tree_shaped_conjunction.py::TestVariable::test_variable_initialization PASSED [ 60%]PASSED [ 61%]PASSED [ 62%]PASSED [ 63%]PASSED [ 64%]PASSED [ 65%]PASSED [ 66%]PASSED [ 67%]PASSED [ 68%]PASSED [ 69%]PASSED [ 70%]PASSED [ 71%]BFS rule simplification timed out, trying DFS...

rule_extraction/test_tree_shaped_conjunction.py::TestVariable::test_get_feature_list 
rule_extraction/test_tree_shaped_conjunction.py::TestWalk::test_walk_single_node 
rule_extraction/test_tree_shaped_conjunction.py::TestWalk::test_walk_depth_first 
rule_extraction/test_tree_shaped_conjunction.py::TestWalk::test_walk_is_stable_when_children_added_during_iteration 
rule_extraction/test_tree_shaped_conjunction.py::TestTreeShapedConjunction::test_tree_with_only_root 
rule_extraction/test_tree_shaped_conjunction.py::TestTreeShapedConjunction::test_len_counts_all_nodes 
rule_extraction/test_tree_shaped_conjunction.py::TestTreeShapedConjunction::test_walk_delegates_to_root_node 
utils/test_bitset.py::test_init_empty PASSED [ 71%]PASSED [ 72%]PASSED [ 73%]PASSED [ 74%]PASSED [ 75%]PASSED [ 76%]PASSED [ 77%]PASSED [ 78%]
utils/test_bitset.py::test_from_subset 
utils/test_bitset.py::test_from_subset_out_of_range_raises[subset0] 
utils/test_bitset.py::test_intersection 
utils/test_bitset.py::test_difference 
utils/test_bitset.py::test_elements_are_sorted 
utils/test_bitset.py::test_as_set 
utils/test_bitset.py::test_repr 
utils/test_bitset.py::test_set_operations_return_new_instances 
utils/test_utils.py::TestBackpropagateRelevance::test_backpropagate_relevance_empty PASSED                             [ 79%]PASSED                            [ 80%]PASSED [ 81%]
utils/test_bitset.py::test_from_subset_out_of_range_raises[subset1] PASSED [ 82%]
utils/test_bitset.py::test_from_subset_out_of_range_raises[subset2] PASSED [ 83%]
utils/test_bitset.py::test_contains[subset0-0-True] PASSED               [ 84%]
utils/test_bitset.py::test_contains[subset1-2-True] PASSED               [ 85%]
utils/test_bitset.py::test_contains[subset2-1-False] PASSED              [ 85%]
utils/test_bitset.py::test_contains[subset3-0-False] PASSED              [ 86%]
utils/test_bitset.py::test_union PASSED                                  [ 87%]PASSED                           [ 88%]PASSED                             [ 89%]PASSED                    [ 90%]PASSED                                 [ 91%]PASSED                                   [ 92%]PASSED    [ 93%]
utils/test_utils.py::TestBackpropagateRelevance::test_backpropagate_relevance_with_activations 
utils/test_utils.py::TestBackpropagateRelevance::test_zero_activations_cancel_everything 
utils/test_utils.py::TestBackpropagateRelevance::test_backpropagate_relevance_activations_filter_everything 
utils/test_utils.py::TestBackpropagateRelevance::test_backpropagate_relevance_empty_mask_returns_empty 
utils/test_utils.py::TestBackpropagateRelevance::test_backpropagate_relevance_dimension_mismatch 
utils/test_utils.py::TestBackpropagateRelevance::test_backpropagate_relevance_multiple_relevant_rows 

============================ 107 passed in 13.23s =============================
PASSED [ 94%]PASSED [ 95%]PASSED [ 96%]PASSED [ 97%]PASSED [ 98%]PASSED [ 99%]PASSED [100%]
Process finished with exit code 0

```